### PR TITLE
Use object declaration

### DIFF
--- a/src/main/kotlin/Singleton.kt
+++ b/src/main/kotlin/Singleton.kt
@@ -1,15 +1,13 @@
-class PrinterDriver() {
-    fun print() = println("Printing with object: $this")
-
-    companion object {
-        val instance: PrinterDriver by lazy {
-            PrinterDriver().apply { println("Initializing with object: $this") }
-        }
+object PrinterDriver {
+    init {
+        println("Initializing with object: $this")
     }
+
+    fun print() = println("Printing with object: $this")
 }
 
 fun main(args: Array<String>) {
     println("Start")
-    PrinterDriver.instance.print()
-    PrinterDriver.instance.print()
+    PrinterDriver.print()
+    PrinterDriver.print()
 }


### PR DESCRIPTION
Instead of using a companion object and creating a lazy instance, just use an object declaration.
