### PR TITLE
Changed Singleton to its natural static method getInstance()

### DIFF
--- a/src/main/kotlin/Singleton.kt
+++ b/src/main/kotlin/Singleton.kt
@@ -1,13 +1,51 @@
-object PrinterDriver {
-    init {
-        println("Initializing with object: $this")
+class main
+{
+    companion object
+    {
+        @JvmStatic
+        fun main(args: Array<String>)
+        {
+            println(Singleton.getSingleton().toString())
+        }
     }
 
-    fun print() = println("Printing with object: $this")
 }
 
-fun main(args: Array<String>) {
-    println("Start")
-    PrinterDriver.print()
-    PrinterDriver.print()
+/*
+    class Singleton, private constructor so I won't be able to construct outside
+ */
+class Singleton private constructor()
+{
+    override fun toString():String = "Singleton Instance"
+
+    /*
+        to initate singleton, I need some form of "static", companion object is my alternative
+     */
+    companion object
+    {
+        /*
+            instance object representation, inits to null
+         */
+        private var Instance:Singleton? = null
+
+        /*
+            getInstance, function is already there though
+         */
+        public fun getSingleton():Singleton
+        {
+            /*
+                case we got an instance already
+             */
+            return if(Instance != null)
+                Instance!!
+            else
+            {
+                /*
+                case we need a new instance
+                 */
+                Instance = Singleton()
+                Instance!!
+            }
+        }
+    }
 }


### PR DESCRIPTION
while your implementation works perfectly, it does not describe itself neither how it accepts the Singleton 
design pattern (https://en.wikipedia.org/wiki/Singleton_pattern)

mostly, it's popular to grasp Singleton as a class with private constructor (therefore impossible be created outside itself) with a static function getInstance that can generate an "Instance" of this Singleton,

that Instance is initiated as a classic member of itself as null and when getInstance is called, it will either call its private constructor to initiate itself or return the already initiated value

Though this is called "Lazy implementation"...